### PR TITLE
Add Newsletter and Market Report to list of genres that can display brands

### DIFF
--- a/lib/constants/genres.js
+++ b/lib/constants/genres.js
@@ -3,7 +3,7 @@ exports.DisplayAsPrefix = new Set([
 	'Explainer',
 	'Interview',
 	'Q&A',
-	'Review'
+	'Review',
 ]);
 
 exports.DisplayWithBrand = new Set([
@@ -11,8 +11,10 @@ exports.DisplayWithBrand = new Set([
 	'Explainer',
 	'Feature',
 	'Interview',
+	'Market Report',
+	'Newsletter',
 	'Photo Story',
 	'Q&A',
 	'Research',
-	'Review'
+	'Review',
 ]);


### PR DESCRIPTION
Rich Martin reported that the top story on the Markets page was missing the Global Market Overview tag. This was because genre, Market Report, was not listed as a genre that could display a brand. I chatted with Mus and Guy, and they both agreed we should add it to the list. Mus also asked if we could add 'Newsletter' to the the list.

Feedback welcome 😄 

[Slack thread](https://financialtimes.slack.com/archives/C042NBBTM/p1536659509000100)
[Trello card](https://trello.com/c/lkCP2kdy/261-article-is-missing-the-global-market-overview-annotation)