### PR TITLE
[CON-2717] - Migrate to node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,59 +3,50 @@
 
 references:
 
-  container_config_node:
-    &container_config_node
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
       - image: cimg/node:<< parameters.node-version >>-browsers
     parameters:
       node-version:
-        default: "16.14"
+        default: "18.16"
         type: string
 
   workspace_root: &workspace_root ~/project
 
-  attach_workspace:
-    &attach_workspace
+  attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
 
-  npm_cache_keys:
-    &npm_cache_keys
+  npm_cache_keys: &npm_cache_keys
     keys:
       - v3-dependency-npm-{{ checksum "package-lock.json" }}-
       - v3-dependency-npm-{{ checksum "package-lock.json" }}
       - v3-dependency-npm-
 
-  cache_npm_cache:
-    &cache_npm_cache
+  cache_npm_cache: &cache_npm_cache
     save_cache:
       key: v3-dependency-npm-{{ checksum "package-lock.json" }}-{{ epoch }}
       paths:
         - ./node_modules/
 
-  restore_npm_cache:
-    &restore_npm_cache
+  restore_npm_cache: &restore_npm_cache
     restore_cache:
       <<: *npm_cache_keys
 
-  filters_only_main:
-    &filters_only_main
+  filters_only_main: &filters_only_main
     branches:
       only: main
 
-  filters_ignore_main:
-    &filters_ignore_main
+  filters_ignore_main: &filters_ignore_main
     branches:
       ignore: main
 
-  filters_ignore_tags:
-    &filters_ignore_tags
+  filters_ignore_tags: &filters_ignore_tags
     tags:
       ignore: /.*/
 
-  filters_version_tag:
-    &filters_version_tag
+  filters_version_tag: &filters_version_tag
     tags:
       only:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
@@ -76,11 +67,9 @@ jobs:
       - run:
           name: Checkout next-ci-shared-helpers
           command: git clone --depth 1
-            git@github.com:Financial-Times/next-ci-shared-helpers.git
-            .circleci/shared-helpers
+            git@github.com:Financial-Times/next-ci-shared-helpers.git --branch
+            unpin-heroku .circleci/shared-helpers
       - *restore_npm_cache
-      - node/install-npm:
-          version: "7"
       - run:
           name: Install project dependencies
           command: make install
@@ -147,14 +136,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
   build-test-publish:
     jobs:
@@ -164,7 +153,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -173,13 +162,13 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - publish:
           context: npm-publish-token
           filters:
             <<: *filters_version_tag
           requires:
-            - test-v16.14
+            - test-v18.16
 
   nightly:
     triggers:
@@ -195,7 +184,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -203,7 +192,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.20", "18.16" ]
 
 notify:
   webhooks:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module encapsulates the editorially selected logic for deciding which metad
 
 ## Installation
 
-This is a [Node.js][node] module available through the [npm][npm] registry. Before installing, download and install Node.js. Node.js 12 or higher is required.
+This is a [Node.js][node] module available through the [npm][npm] registry. Before installing, download and install Node.js. Node.js 18 or higher is required.
 
 Installation is done using the [npm install][install] command:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/n-display-metadata",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
         "@financial-times/n-gage": "^8.3.2",
@@ -18,8 +17,8 @@
         "snyk": "^1.167.2"
       },
       "engines": {
-        "node": "16.x",
-        "npm": "7.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -16,16 +16,14 @@
   },
   "scripts": {
     "test": "make test",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "engines": {
-    "node": "16.x",
+    "node": "16.x || 18.x",
     "npm": "7.x || 8.x || 9.x"
   },
   "volta": {
-    "node": "16.14.2",
-    "npm": "7.24.2"
+    "node": "18.16.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
**Description**

PR to achieve upgrade to Node v18. This is part of [migrating to Node v.18 Initiative](https://financialtimes.atlassian.net/browse/CON-2706).

In order to achieve the migration, it has been used the following [migration script](https://github.com/Financial-Times/platform-scripts/tree/7c571c9e8e5e452e6cf16f36fc44b0769c71551f/upgrade-node-18).